### PR TITLE
= all: migrate macros to macro-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,38 +10,60 @@ val commonSettings = androidBuildAar ++ bintrayPublishSettings ++ Seq(
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
 
   scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.5", "2.11.7"),
+  crossScalaVersions := Seq("2.10.6", "2.11.7"),
   javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
-  scalacOptions ++= Seq("-feature", "-deprecation", "-target:jvm-1.7"),
+  scalacOptions ++= Seq(
+    "-feature",
+    "-deprecation",
+    "-target:jvm-1.7",
+    "-encoding", "UTF-8",
+    "-unchecked",
+    "-Xlint",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen"
+  ) ++ (scalaBinaryVersion.value match {
+    case "2.10" => Seq.empty
+    case v => Seq("-Ywarn-unused-import")
+  }),
 
-  libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+  libraryDependencies ++= Seq(
+    "org.scalatest" %% "scalatest" % "2.2.6" % Test,
+    "com.geteit" %% "robotest" % "0.12" % Test,
+    "com.android.support" % "support-v4" % "23.1.1"
+  ),
+
+  parallelExecution in Test := false,
+  fork in Test := true,
+  unmanagedClasspath in Test ++= (bootClasspath in Android).value,
 
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
     .setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, true)
     .setPreference(DoubleIndentClassDeclaration, false)
     .setPreference(MultilineScaladocCommentsStartOnFirstLine, true)
     .setPreference(RewriteArrowSymbols, true)
-)
+) ++ addCommandAlias("testAndCover", "; clean; coverage; test; coverageReport; coverageAggregate")
 
 val paradiseVersion = "2.1.0"
 
-val paradiseSettings = Seq(
+val macroSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+    // required by macro-compat
+    "org.typelevel" %% "macro-compat" % "1.1.1",
+    "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     compilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full)
   ),
 
-  libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 10)) ⇒
-      Seq("org.scalamacros" %% "quasiquotes" % paradiseVersion)
-    case _ ⇒
-      Seq()
+  libraryDependencies ++= (scalaBinaryVersion.value match {
+    case "2.10" => Seq("org.scalamacros" %% "quasiquotes" % paradiseVersion)
+    case _ ⇒ Seq()
   })
 )
 
 lazy val core = (project in file("macroid-core"))
   .settings(commonSettings: _*)
-  .settings(paradiseSettings: _*)
+  .settings(macroSettings: _*)
   .settings(
     name := "macroid",
     description := "A Scala GUI DSL for Android",
@@ -50,7 +72,6 @@ lazy val core = (project in file("macroid-core"))
     unmanagedSourceDirectories in Test := Seq(baseDirectory.value / "src" / "test" / "scala"),
 
     libraryDependencies ++= Seq(
-      "com.android.support" % "support-v4" % "23.1.1",
       "org.scala-lang.modules" %% "scala-async" % "0.9.5",
       "org.scalatest" %% "scalatest" % "2.2.6" % "test"
     )
@@ -81,6 +102,7 @@ lazy val root = (project in file("."))
   .settings(
     publish := (),
     publishLocal := (),
+    scalaVersion := "2.11.7",
     scalacOptions in (Compile, doc) ++= Seq(
       "-sourcepath", baseDirectory.value.getAbsolutePath,
       "-doc-source-url", "https://github.com/macroid/macroid/tree/master€{FILE_PATH}.scala"

--- a/macroid-core/src/main/scala/macroid/Bundles.scala
+++ b/macroid-core/src/main/scala/macroid/Bundles.scala
@@ -2,11 +2,11 @@ package macroid
 
 import scala.language.experimental.macros
 import android.os.Bundle
-import scala.reflect.macros.{ Context ⇒ MacroContext }
+import macrocompat.bundle
+import scala.reflect.macros.blackbox
 
 private[macroid] trait Bundles {
-  import BundleMacros._
-  def bundle(pairs: (String, Any)*): Bundle = macro bundleImpl
+  def bundle(pairs: (String, Any)*): Bundle = macro BundleMacros.bundleImpl
 
   implicit class BundleAddition(b: Bundle) {
     def +(other: Bundle) = {
@@ -20,24 +20,25 @@ private[macroid] trait Bundles {
 
 object Bundles extends Bundles
 
-object BundleMacros {
-  def bundleImpl(c: MacroContext)(pairs: c.Expr[(String, Any)]*) = {
-    import c.universe._
+@bundle
+class BundleMacros(val c: blackbox.Context) {
+  import c.universe._
 
+  def bundleImpl(pairs: c.Expr[(String, Any)]*): Tree = {
     val (singular, plural) = weakTypeOf[Bundle].members
       .filter(_.name.toString.startsWith("put"))
       .filterNot(_.name.toString == "putAll")
       .map(_.asMethod)
       .partition(x ⇒ (!x.name.toString.endsWith("Array") && !x.name.toString.endsWith("List")) || x.name.toString.contains("Sparse"))
     val (plain, able) = singular.partition(!_.name.toString.endsWith("able"))
-    val b = newTermName(c.fresh("bundle"))
+    val b = TermName(c.freshName("bundle"))
     val puts = pairs map { pair ⇒
       val TypeRef(_, _, List(_, value)) = pair.actualType
-      val put = plain.find(value =:= _.paramss(0)(1).typeSignature) orElse
-        able.find(value <:< _.paramss(0)(1).typeSignature) getOrElse
+      val put = plain.find(value =:= _.paramLists(0)(1).typeSignature) orElse
+        able.find(value <:< _.paramLists(0)(1).typeSignature) getOrElse
         c.abort(pair.tree.pos, s"Could not put $value in a Bundle")
       q"$b.$put($pair._1, $pair._2)"
     }
-    c.Expr[Bundle](q"val $b = new _root_.android.os.Bundle; ..$puts; $b")
+    q"val $b = new _root_.android.os.Bundle; ..$puts; $b"
   }
 }

--- a/macroid-core/src/main/scala/macroid/Contexts.scala
+++ b/macroid-core/src/main/scala/macroid/Contexts.scala
@@ -9,7 +9,7 @@ import macroid.support.{ Fragment, FragmentApi }
 /** A wrapper that contains two contexts:
   * 1. the application context (which should be always alive)
   * 2. the current context, usually Activity or Service
-  *   (which is more specific, but may die and is stored as a weak reference)
+  * (which is more specific, but may die and is stored as a weak reference)
   */
 @implicitNotFound("""Could not find a `ContextWrapper`.
 If you are inside Activity, Fragment or Service, extend Contexts[Activity], Contexts[Fragment] or Contexts[Service],

--- a/macroid-core/src/main/scala/macroid/LayoutBuilding.scala
+++ b/macroid-core/src/main/scala/macroid/LayoutBuilding.scala
@@ -2,29 +2,29 @@ package macroid
 
 import scala.language.experimental.macros
 import android.view.{ ViewGroup, View }
-import scala.reflect.macros.{ Context ⇒ MacroContext }
+import macrocompat.bundle
+import scala.reflect.macros.blackbox
 
 /** This trait contains basic building blocks used to define layouts: w, l and slot */
 private[macroid] trait LayoutBuilding {
-  import LayoutBuildingMacros._
 
   /** Define a widget */
-  def widget[W <: View](implicit ctx: ContextWrapper): Ui[W] = macro widgetImpl[W]
+  def widget[W <: View](implicit ctx: ContextWrapper): Ui[W] = macro LayoutBuildingMacros.widgetImpl[W]
 
   /** Define a widget (an alias for `widget`) */
-  def w[W <: View](implicit ctx: ContextWrapper): Ui[W] = macro widgetImpl[W]
+  def w[W <: View](implicit ctx: ContextWrapper): Ui[W] = macro LayoutBuildingMacros.widgetImpl[W]
 
   /** Define a widget, supplying additional arguments */
-  def widget[W <: View](args: Any*)(implicit ctx: ContextWrapper): Ui[W] = macro widgetArgImpl[W]
+  def widget[W <: View](args: Any*)(implicit ctx: ContextWrapper): Ui[W] = macro LayoutBuildingMacros.widgetArgImpl[W]
 
   /** Define a widget, supplying additional arguments (an alias for `widget`) */
-  def w[W <: View](args: Any*)(implicit ctx: ContextWrapper): Ui[W] = macro widgetArgImpl[W]
+  def w[W <: View](args: Any*)(implicit ctx: ContextWrapper): Ui[W] = macro LayoutBuildingMacros.widgetArgImpl[W]
 
   /** Define a layout */
-  def layout[L <: ViewGroup](children: Ui[View]*)(implicit ctx: ContextWrapper): Ui[L] = macro layoutUiImpl[L]
+  def layout[L <: ViewGroup](children: Ui[View]*)(implicit ctx: ContextWrapper): Ui[L] = macro LayoutBuildingMacros.layoutUiImpl[L]
 
   /** Define a layout (an alias for `layout`) */
-  def l[L <: ViewGroup](children: Ui[View]*)(implicit ctx: ContextWrapper): Ui[L] = macro layoutUiImpl[L]
+  def l[L <: ViewGroup](children: Ui[View]*)(implicit ctx: ContextWrapper): Ui[L] = macro LayoutBuildingMacros.layoutUiImpl[L]
 
   /** Define a slot */
   def slot[W <: View]: Option[W] = None
@@ -32,20 +32,20 @@ private[macroid] trait LayoutBuilding {
 
 object LayoutBuilding extends LayoutBuilding
 
-object LayoutBuildingMacros {
-  def widgetImpl[W <: View: c.WeakTypeTag](c: MacroContext)(ctx: c.Expr[ContextWrapper]): c.Expr[W] = {
-    import c.universe._
-    c.Expr[W](q"_root_.macroid.Ui(new ${weakTypeOf[W]}($ctx.getOriginal))")
+@bundle
+class LayoutBuildingMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  def widgetImpl[W <: View: c.WeakTypeTag](ctx: c.Expr[ContextWrapper]): Tree = {
+    q"_root_.macroid.Ui(new ${weakTypeOf[W]}($ctx.getOriginal))"
   }
 
-  def widgetArgImpl[W <: View: c.WeakTypeTag](c: MacroContext)(args: c.Expr[Any]*)(ctx: c.Expr[ContextWrapper]): c.Expr[W] = {
-    import c.universe._
-    c.Expr[W](q"_root_.macroid.Ui(new ${weakTypeOf[W]}($ctx.getOriginal, ..$args))")
+  def widgetArgImpl[W <: View: c.WeakTypeTag](args: c.Expr[Any]*)(ctx: c.Expr[ContextWrapper]): Tree = {
+    q"_root_.macroid.Ui(new ${weakTypeOf[W]}($ctx.getOriginal, ..$args))"
   }
 
-  def layoutUiImpl[L <: ViewGroup: c.WeakTypeTag](c: MacroContext)(children: c.Expr[Ui[View]]*)(ctx: c.Expr[ContextWrapper]): c.Expr[L] = {
-    import c.universe._
-    val untypechecked = children.map(ch ⇒ c.resetLocalAttrs(ch.tree))
-    c.Expr[L](q"_root_.macroid.Ui.sequence(..$untypechecked).map(ch ⇒ new ${weakTypeOf[L]}($ctx.getOriginal) { ch.foreach(this.addView) })")
+  def layoutUiImpl[L <: ViewGroup: c.WeakTypeTag](children: c.Expr[Ui[View]]*)(ctx: c.Expr[ContextWrapper]): Tree = {
+    val untypechecked = children.map(ch ⇒ c.untypecheck(ch.tree))
+    q"_root_.macroid.Ui.sequence(..$untypechecked).map(ch ⇒ new ${weakTypeOf[L]}($ctx.getOriginal) { ch.foreach(this.addView) })"
   }
 }

--- a/macroid-core/src/main/scala/macroid/Searching.scala
+++ b/macroid-core/src/main/scala/macroid/Searching.scala
@@ -10,9 +10,9 @@ import macroid.support.{ Fragment, FragmentApi }
 /** A class to generate unique ids
   * The recommended usage is to create a singleton for the entire app:
   * {{{
-  *  object Id extends IdGen(1000)
-  *  ...
-  *  w[Button] <~ id(Id.button)
+  * object Id extends IdGen(1000)
+  * ...
+  * w[Button] <~ id(Id.button)
   * }}}
   *
   * @param start  The starting id.

--- a/macroid-core/src/main/scala/macroid/Snails.scala
+++ b/macroid-core/src/main/scala/macroid/Snails.scala
@@ -13,6 +13,7 @@ private[macroid] object SnailScheduler {
   val scheduler = Executors.newScheduledThreadPool(1)
   def snailSchedulerEc(millis: Long) = new ExecutionContext {
     def execute(runnable: Runnable) = scheduler.schedule(runnable, millis, TimeUnit.MILLISECONDS)
+
     def reportFailure(t: Throwable) = t.printStackTrace()
   }
 }
@@ -52,9 +53,9 @@ private[macroid] trait AnimationSnails extends VisibilityTweaks {
   def anim(animation: Animation, duration: Long = -1L) = Snail[View] { x ⇒
     val animPromise = Promise[Unit]()
     animation.setAnimationListener(new AnimationListener {
-      override def onAnimationStart(a: Animation) {}
-      override def onAnimationRepeat(a: Animation) {}
-      override def onAnimationEnd(a: Animation) { animPromise.complete(Success(())) }
+      override def onAnimationStart(a: Animation) = {}
+      override def onAnimationRepeat(a: Animation) = {}
+      override def onAnimationEnd(a: Animation) = { animPromise.complete(Success(())) }
     })
     if (duration >= 0) animation.setDuration(duration)
     x.startAnimation(animation)

--- a/macroid-core/src/main/scala/macroid/Tweaks.scala
+++ b/macroid-core/src/main/scala/macroid/Tweaks.scala
@@ -5,11 +5,10 @@ import scala.language.experimental.macros
 import android.text.Html
 import android.view.{ ViewGroup, View }
 import android.widget.{ LinearLayout, TextView }
-import scala.reflect.macros.{ Context ⇒ MacroContext }
+import macrocompat.bundle
+import scala.reflect.macros.blackbox
 
 private[macroid] trait BasicTweaks {
-  import BasicTweakMacros._
-
   /** Set this view’s id */
   def id(id: Int) = Tweak[View](_.setId(id))
 
@@ -17,9 +16,9 @@ private[macroid] trait BasicTweaks {
   def hold[A](value: A) = Tweak[View](_.setTag(value))
 
   /** Assign the view to the provided `var` */
-  def wire[W <: View](v: W): Tweak[W] = macro wireImpl[W]
+  def wire[W <: View](v: W): Tweak[W] = macro BasicTweakMacros.wireImpl[W]
   /** Assign the view to the provided slot */
-  def wire[W <: View](v: Option[W]): Tweak[W] = macro wireOptionImpl[W]
+  def wire[W <: View](v: Option[W]): Tweak[W] = macro BasicTweakMacros.wireOptionImpl[W]
 }
 
 private[macroid] trait VisibilityTweaks {
@@ -52,12 +51,11 @@ private[macroid] trait PaddingTweaks {
 }
 
 private[macroid] trait LayoutTweaks {
-  import LayoutTweakMacros._
 
   /** Use `LayoutParams` of the specified layout class */
-  def layoutParams[L <: ViewGroup](params: Any*): Tweak[View] = macro layoutParamsImpl[L]
+  def layoutParams[L <: ViewGroup](params: Any*): Tweak[View] = macro LayoutTweakMacros.layoutParamsImpl[L]
   /** Use `LayoutParams` of the specified layout class */
-  def lp[L <: ViewGroup](params: Any*): Tweak[View] = macro layoutParamsImpl[L]
+  def lp[L <: ViewGroup](params: Any*): Tweak[View] = macro LayoutTweakMacros.layoutParamsImpl[L]
 
   /** Make this layout vertical */
   val vertical = Tweak[LinearLayout](_.setOrientation(LinearLayout.VERTICAL))
@@ -96,16 +94,15 @@ private[macroid] trait TextTweaks {
 }
 
 private[macroid] trait EventTweaks {
-  import EventTweakMacros._
 
   object On extends Dynamic {
     /** Set event handler */
-    def applyDynamic[W <: View](event: String)(handler: Ui[Any]): Tweak[W] = macro onUnitImpl[W]
+    def applyDynamic[W <: View](event: String)(handler: Ui[Any]): Tweak[W] = macro EventTweakMacros.onUnitImpl[W]
   }
 
   object FuncOn extends Dynamic {
     /** Set event handler */
-    def applyDynamic[W <: View](event: String)(handler: Any): Tweak[W] = macro onFuncImpl[W]
+    def applyDynamic[W <: View](event: String)(handler: Any): Tweak[W] = macro EventTweakMacros.onFuncImpl[W]
   }
 }
 
@@ -121,61 +118,64 @@ private[macroid] trait Tweaks
 
 object Tweaks extends Tweaks
 
-object BasicTweakMacros {
-  def wireImpl[W <: View: c.WeakTypeTag](c: MacroContext)(v: c.Expr[W]): c.Expr[Tweak[W]] = {
-    import c.universe._
-    c.Expr[Tweak[W]](q"_root_.macroid.Tweak[${weakTypeOf[W]}] { x ⇒ $v = x }")
+@bundle
+class BasicTweakMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  def wireImpl[W <: View: c.WeakTypeTag](v: c.Expr[W]): Tree = {
+    q"_root_.macroid.Tweak[${weakTypeOf[W]}] { x ⇒ $v = x }"
   }
 
-  def wireOptionImpl[W <: View: c.WeakTypeTag](c: MacroContext)(v: c.Expr[Option[W]]): c.Expr[Tweak[W]] = {
-    import c.universe._
-    c.Expr[Tweak[W]](q"_root_.macroid.Tweak[${weakTypeOf[W]}] { x ⇒ $v = Some(x) }")
+  def wireOptionImpl[W <: View: c.WeakTypeTag](v: c.Expr[Option[W]]): Tree = {
+    q"_root_.macroid.Tweak[${weakTypeOf[W]}] { x ⇒ $v = Some(x) }"
   }
 }
 
-object LayoutTweakMacros {
-  def layoutParams(c: MacroContext)(l: c.Type, params: Seq[c.Expr[Any]]) = {
-    import c.universe._
-    q"_root_.macroid.Tweak[_root_.android.view.View] { x ⇒ x.setLayoutParams(new ${l.typeSymbol.companionSymbol}.LayoutParams(..$params)) }"
+@bundle
+class LayoutTweakMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  def layoutParams(l: c.Type, params: Seq[c.Expr[Any]]) = {
+    q"_root_.macroid.Tweak[_root_.android.view.View] { x ⇒ x.setLayoutParams(new ${l.typeSymbol.companion}.LayoutParams(..$params)) }"
   }
 
-  def findLayoutParams(c: MacroContext)(layoutType: c.Type, params: Seq[c.Expr[Any]]): c.Expr[Tweak[View]] = {
-    import c.universe._
+  def findLayoutParams(layoutType: c.Type, params: Seq[c.Expr[Any]]): Tree = {
     var tp = layoutType
 
     // go up the inheritance chain until we find a suitable LayoutParams class in the companion
-    while (scala.util.Try(c.typeCheck(layoutParams(c)(tp, params))).isFailure) {
+    while (scala.util.Try(c.typecheck(layoutParams(tp, params))).isFailure) {
       if (tp.baseClasses.length > 2) {
         tp = tp.baseClasses(1).asType.toType
       } else {
         c.abort(c.enclosingPosition, "Could not find the appropriate LayoutParams constructor")
       }
     }
-    c.Expr[Tweak[View]](layoutParams(c)(tp, params))
+    layoutParams(tp, params)
   }
 
-  def layoutParamsImpl[L <: ViewGroup: c.WeakTypeTag](c: MacroContext)(params: c.Expr[Any]*): c.Expr[Tweak[View]] = {
-    findLayoutParams(c)(c.weakTypeOf[L], params)
+  def layoutParamsImpl[L <: ViewGroup: c.WeakTypeTag](params: c.Expr[Any]*): Tree = {
+    findLayoutParams(c.weakTypeOf[L], params)
   }
 }
 
-object EventTweakMacros {
-  def onBase(c: MacroContext)(event: c.Expr[String], tp: c.Type) = {
-    import c.universe._
+@bundle
+class EventTweakMacros(val c: blackbox.Context) {
+  import c.universe._
 
+  private def onBase(event: c.Expr[String], tp: c.Type) = {
     // find the setter
     val Expr(Literal(Constant(eventName: String))) = event
     val setter = scala.util.Try {
-      val s = tp.member(newTermName(s"setOn${eventName.capitalize}Listener")).asMethod
+      val s = tp.member(TermName(s"setOn${eventName.capitalize}Listener")).asMethod
       assert(s != NoSymbol); s
     } getOrElse {
       c.abort(c.enclosingPosition, s"Could not find method setOn${eventName.capitalize}Listener in $tp. You may need to provide the type argument explicitly")
     }
 
     // find the method to override
-    val listener = setter.paramss(0)(0).typeSignature
+    val listener = setter.paramLists(0)(0).typeSignature
     val on = scala.util.Try {
-      val x = listener.member(newTermName(s"on${eventName.capitalize}")).asMethod
+      val x = listener.member(TermName(s"on${eventName.capitalize}")).asMethod
       assert(x != NoSymbol); x
     } getOrElse {
       c.abort(c.enclosingPosition, s"Unsupported event listener class in $setter")
@@ -188,10 +188,9 @@ object EventTweakMacros {
   object FuncListener extends ListenerType
   object UnitListener extends ListenerType
 
-  def getListener(c: MacroContext)(tpe: c.Type, setter: c.universe.MethodSymbol, listener: c.Type, on: c.universe.MethodSymbol, f: c.Expr[Any], mode: ListenerType) = {
-    import c.universe._
-    val args = on.paramss(0).map(_ ⇒ newTermName(c.fresh("arg")))
-    val params = args zip on.paramss(0) map { case (a, p) ⇒ q"val $a: ${p.typeSignature}" }
+  def getListener(tpe: c.Type, setter: c.universe.MethodSymbol, listener: c.Type, on: c.universe.MethodSymbol, f: c.Expr[Any], mode: ListenerType): Tree = {
+    val args = on.paramLists(0).map(_ ⇒ TermName(c.freshName("arg")))
+    val params = args zip on.paramLists(0) map { case (a, p) ⇒ q"val $a: ${p.typeSignature}" }
     lazy val argIdents = args.map(a ⇒ Ident(a))
     val impl = mode match {
       case FuncListener ⇒ q"$f(..$argIdents).get"
@@ -200,26 +199,22 @@ object EventTweakMacros {
     q"_root_.macroid.Tweak[$tpe] { x ⇒ x.$setter(new $listener { override def ${on.name.toTermName}(..$params) = $impl })}"
   }
 
-  def onUnitImpl[W <: View: c.WeakTypeTag](c: MacroContext)(event: c.Expr[String])(handler: c.Expr[Ui[Any]]) = {
-    import c.universe._
-
-    val (setter, listener, on, tp) = onBase(c)(event, weakTypeOf[W])
+  def onUnitImpl[W <: View: c.WeakTypeTag](event: c.Expr[String])(handler: c.Expr[Ui[Any]]): Tree = {
+    val (setter, listener, on, tp) = onBase(event, weakTypeOf[W])
     scala.util.Try {
       if (!(on.returnType =:= typeOf[Unit])) assert((handler.actualType match { case TypeRef(_, _, t :: _) ⇒ t }) <:< on.returnType)
-      c.Expr[Tweak[View]](getListener(c)(tp, setter, listener, on, c.Expr(c.resetLocalAttrs(handler.tree)), UnitListener))
+      getListener(tp, setter, listener, on, c.Expr(c.untypecheck(handler.tree)), UnitListener)
     } getOrElse {
       c.abort(c.enclosingPosition, s"handler should be of type Ui[${on.returnType}]")
     }
   }
 
-  def onFuncImpl[W <: View: c.WeakTypeTag](c: MacroContext)(event: c.Expr[String])(handler: c.Expr[Any]) = {
-    import c.universe._
-
-    val (setter, listener, on, tp) = onBase(c)(event, weakTypeOf[W])
+  def onFuncImpl[W <: View: c.WeakTypeTag](event: c.Expr[String])(handler: c.Expr[Any]): Tree = {
+    val (setter, listener, on, tp) = onBase(event, weakTypeOf[W])
     scala.util.Try {
-      c.Expr[Tweak[View]](c.typeCheck(getListener(c)(tp, setter, listener, on, c.Expr(c.resetLocalAttrs(handler.tree)), FuncListener)))
+      c.typecheck(getListener(tp, setter, listener, on, c.Expr(c.untypecheck(handler.tree)), FuncListener))
     } getOrElse {
-      c.abort(c.enclosingPosition, s"handler should have type signature ${on.paramss.head.mkString("(", ",", ")")}⇒Ui[${on.returnType}]")
+      c.abort(c.enclosingPosition, s"handler should have type signature ${on.paramLists.head.mkString("(", ",", ")")}⇒Ui[${on.returnType}]")
     }
   }
 }

--- a/macroid-core/src/main/scala/macroid/contrib/ExtraTweaks.scala
+++ b/macroid-core/src/main/scala/macroid/contrib/ExtraTweaks.scala
@@ -37,7 +37,7 @@ object TextTweaks {
   val date = Tweak[W](x ⇒ x.setInputType(InputType.TYPE_CLASS_DATETIME))
   val phone = Tweak[W](x ⇒ x.setInputType(InputType.TYPE_CLASS_PHONE))
 
-  def size(points: Int) = Tweak[W](_.setTextSize(TypedValue.COMPLEX_UNIT_SP, points))
+  def size(points: Int) = Tweak[W](_.setTextSize(TypedValue.COMPLEX_UNIT_SP, points.toFloat))
   val medium = size(18)
   val large = size(22)
 

--- a/macroid-core/src/test/scala/macroid/BundlesSpec.scala
+++ b/macroid-core/src/test/scala/macroid/BundlesSpec.scala
@@ -1,0 +1,14 @@
+package macroid
+
+import org.scalatest.{ Matchers, FlatSpec, RobolectricSuite }
+import macroid.FullDsl._
+import android.os.Bundle
+
+class BundlesSpec extends FlatSpec with RobolectricSuite with Matchers {
+
+  "Bundles" should "allow two bundles to be combined" in {
+    val result = bundle("a" → 1) + bundle("b" → 2)
+    result should ===(bundle("a" → 1, "b" → 2))
+  }
+
+}

--- a/macroid-core/src/test/scala/macroid/ExcerptingSpec.scala
+++ b/macroid-core/src/test/scala/macroid/ExcerptingSpec.scala
@@ -3,7 +3,6 @@ package macroid
 import android.widget.Button
 import org.scalatest.FlatSpec
 
-import macroid._
 import macroid.FullDsl._
 
 import scala.concurrent.Future

--- a/macroid-core/src/test/scala/macroid/FragmentApiSpec.scala
+++ b/macroid-core/src/test/scala/macroid/FragmentApiSpec.scala
@@ -6,7 +6,7 @@ import macroid.FullDsl._
 class FragmentApiSpec extends FlatSpec {
   "FragmentApi" should "work with legacy fragments in activity" in {
     import android.support.v4.app.{ FragmentActivity, Fragment }
-    def foo = {
+    def foo() = {
       class MyActivity extends FragmentActivity with Contexts[FragmentActivity] {
         f[Fragment].framed(1, "1")
         this.findFrag[Fragment]("1")
@@ -16,7 +16,7 @@ class FragmentApiSpec extends FlatSpec {
 
   it should "work with modern fragments in activity" in {
     import android.app.{ Activity, Fragment }
-    def foo = {
+    def foo() = {
       class MyActivity extends Activity with Contexts[Activity] {
         f[Fragment].framed(1, "1")
         this.findFrag[Fragment]("1")
@@ -26,7 +26,7 @@ class FragmentApiSpec extends FlatSpec {
 
   it should "work with legacy fragments in fragment" in {
     import android.support.v4.app.Fragment
-    def foo = {
+    def foo() = {
       class MyFragment extends Fragment with Contexts[Fragment] {
         f[Fragment].framed(1, "1")
         this.findFrag[Fragment]("1")
@@ -36,7 +36,7 @@ class FragmentApiSpec extends FlatSpec {
 
   it should "work with modern fragments in fragment" in {
     import android.app.Fragment
-    def foo = {
+    def foo() = {
       class MyFragment extends Fragment with Contexts[Fragment] {
         f[Fragment].framed(1, "1")
         this.findFrag[Fragment]("1")

--- a/macroid-core/src/test/scala/macroid/SnailingSpec.scala
+++ b/macroid-core/src/test/scala/macroid/SnailingSpec.scala
@@ -3,7 +3,6 @@ package macroid
 import android.widget.{ TextView, Button }
 import org.scalatest.FlatSpec
 
-import macroid._
 import macroid.FullDsl._
 
 import scala.concurrent.Future

--- a/macroid-core/src/test/scala/macroid/TweakingSpec.scala
+++ b/macroid-core/src/test/scala/macroid/TweakingSpec.scala
@@ -10,46 +10,46 @@ class TweakingSpec extends FlatSpec {
   implicit val ctx: ContextWrapper = null
 
   "Tweaking" should "work with widgets and tweaks" in {
-    def foo = {
+    def foo() = {
       val action = Ui(println("Hmm..."))
       w[Button] <~ On.click(action) <~ text("Hi") <~ id(2) <~ text("Hey") <~ On.click(action)
     }
   }
 
   it should "work with effectors on the left" in {
-    def foo = {
+    def foo() = {
       Option(List(w[Button], w[TextView])) <~ show
     }
   }
 
   it should "work with effectors on the right" in {
-    def foo = {
+    def foo() = {
       w[Button] <~ Option(List(show, text("doge")))
     }
   }
 
   it should "work with effectors on both sides" in {
-    def foo = {
+    def foo() = {
       Option(List(w[Button], w[TextView])) <~ Option(List(show, text("doge")))
     }
   }
 
   it should "use provided widget type" in {
-    def foo = {
+    def foo() = {
       w[Button] <~ Tweak[Button] { _.setText("test") }
       Option(w[Button]) <~ Tweak[Button] { _.setText("test") }
     }
   }
 
   it should "allow setting method handlers" in {
-    def foo = {
+    def foo() = {
       w[Button] <~ On.click(Ui(println("duh")))
       w[Button] <~ On.editorAction[Button] { for (_ ← Ui(println("duhduh"))) yield true }
     }
   }
 
   it should "use provided layout type" in {
-    def foo = {
+    def foo() = {
       l[LinearLayout](
         w[TextView] <~ lp[LinearLayout](0, 0, 1.0f)
       )
@@ -58,13 +58,13 @@ class TweakingSpec extends FlatSpec {
   }
 
   "TextTweaks.allCaps" should "be invokeable without parentheses" in {
-    def foo = {
+    def foo() = {
       w[TextView] <~ TextTweaks.allCaps
     }
   }
 
   it should "allow an optional value" in {
-    def foo = {
+    def foo() = {
       w[TextView] <~ TextTweaks.allCaps(false)
     }
   }

--- a/macroid-viewable/src/main/scala/macroid/viewable/SlottedListable.scala
+++ b/macroid-viewable/src/main/scala/macroid/viewable/SlottedListable.scala
@@ -1,7 +1,6 @@
 package macroid.viewable
 
 import android.view.View
-import macroid.LayoutDsl._
 import macroid.Tweaks._
 import macroid.util.SafeCast
 import macroid.{ ContextWrapper, Ui }
@@ -10,19 +9,19 @@ import macroid.{ ContextWrapper, Ui }
 trait SlottedListable[A] extends Listable[A, View] {
   /** The slots type. Example:
     * {{{
-    *  class Slots {
-    *    var textView = slot[TextView]
-    *    var imageView = slot[ImageView]
-    *  }
+    * class Slots {
+    * var textView = slot[TextView]
+    * var imageView = slot[ImageView]
+    * }
     * }}}
     */
   type Slots
 
   /** Create the layout and a `Slots` instance, wire the slots, and return both. Example:
     * {{{
-    *  val slots = new Slots
-    *  val view = w[TextView] <~ wire(slots.textView)
-    *  (view, slots)
+    * val slots = new Slots
+    * val view = w[TextView] <~ wire(slots.textView)
+    * (view, slots)
     * }}}
     */
   def makeSlots(viewType: Int)(implicit ctx: ContextWrapper): (Ui[View], Slots)


### PR DESCRIPTION
Added scalac flags that revealed many warnings. Migrated macros to
macro-compat to deal with many of them. Configured tests using
roboelectric and added simple test for Bundles.