### PR TITLE
Adding implicit ContextWrapper for Views

### DIFF
--- a/macroid-docs/guide/Contexts.md
+++ b/macroid-docs/guide/Contexts.md
@@ -15,8 +15,8 @@ This is done with the `ContextWrapper` trait, which has four methods:
 * `contextWrapper.bestAvailable` will return the original context if it’s available,
   otherwise — the application context.
 
-There are a few specialized cases of `ContextWrapper`: `ActivityContextWrapper`, `ServiceContextWrapper`
-and `ApplicationContextWrapper`.
+There are a few specialized cases of `ContextWrapper`: `ActivityContextWrapper`, `ServiceContextWrapper`,
+`ApplicationContextWrapper` and `GenericContextWrapper`.
 
 ## Including
 
@@ -39,10 +39,18 @@ class MyActivity extends FragmentActivity with Contexts[FragmentActivity] {
 }
 ```
 
-Finally, in a fragment (either `android.app.Fragment` or `android.support.v4.app.Fragment`):
+In a fragment (either `android.app.Fragment` or `android.support.v4.app.Fragment`):
 
 ```scala
 class MyFragment extends Fragment with Contexts[Fragment] {
+  ...
+}
+```
+
+Finally, if you want to include the implicit context in your views:
+
+```scala
+class MyFrameLayout extends FrameLayout with Contexts[View] {
   ...
 }
 ```


### PR DESCRIPTION
This PR brings the ability to create `ContextWrapper` implicit in our custom views

For now, if you are using XML Layouts and you need `ContextWrapper` there isn't an easy way for do it. With this contribution, we can do that:

```scala
class MyFrameLayout(context: Context, attr: AttributeSet, defStyleAttr: Int)
  extends FrameLayout(context, attr, defStyleAttr)
  with Contexts[View] {

  def this(context: Context) = this(context, javaNull, 0)

  def this(context: Context, attr: AttributeSet) = this(context, attr, 0)

....

}
```

@stanch can you please review? Thanks!