### PR TITLE
Infinite list adapter that handles additional data loading

### DIFF
--- a/macroid-viewable/src/main/scala/macroid/viewable/PageableList.scala
+++ b/macroid-viewable/src/main/scala/macroid/viewable/PageableList.scala
@@ -1,0 +1,71 @@
+package macroid.viewable
+
+import android.view.View
+import android.widget.AbsListView.OnScrollListener
+import android.widget.AdapterView.OnItemClickListener
+import android.widget.{ AbsListView, AdapterView }
+import macroid.{ ContextWrapper, Tweak }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+/** Created by Alexey Afanasev on 04.03.16.
+  */
+trait PageableList {
+
+  /** Adapter tweak for infinite list that automatically fetches additional data when scrolled down to the bottom
+    *
+    * @param loadMoreItems  input data accessor that takes offset position and returns future with result and total items count available
+    * @param listable is about creating layout from data
+    * @param dataLoaded callback to handle empty tale
+    * @tparam A data type param
+    * @return
+    */
+  def pagingAdapterTweak[A](loadMoreItems: Long ⇒ Future[(Seq[A], Long)], listable: Listable[A, _], dataLoaded: Long ⇒ Unit = _ ⇒ ())(implicit cw: ContextWrapper, ec: ExecutionContext): Future[Tweak[AbsListView]] = {
+    loadMoreItems(0) map {
+      case (firstPage: Seq[A], total: Long) ⇒
+        listable.listAdapterTweak(firstPage) + Tweak[AbsListView](l ⇒ {
+          var isLoading = false
+          var totalOutThere = total
+
+          dataLoaded(total)
+
+          def load(a: ListableListAdapter[A, _], lastVisibleItem: Int): Unit = {
+            isLoading = true
+            loadMoreItems(lastVisibleItem) map {
+              case (nextPage: Seq[A], total: Long) ⇒
+                isLoading = false
+                totalOutThere = total
+                a.addAll(nextPage: _*)
+            }
+          }
+
+          l.setOnScrollListener(new OnScrollListener {
+            override def onScrollStateChanged(absListView: AbsListView, i: Int): Unit = {
+            }
+
+            override def onScroll(absListView: AbsListView, firstVisibleItem: Int, visibleItemCount: Int, totalLoadedItemCount: Int): Unit = {
+              val lastVisibleItem = firstVisibleItem + visibleItemCount
+              absListView.getAdapter match {
+                case a: ListableListAdapter[A, _] if lastVisibleItem == totalLoadedItemCount && !isLoading && totalOutThere > totalLoadedItemCount ⇒
+                  load(a, lastVisibleItem)
+                case _ ⇒
+              }
+            }
+          })
+        })
+    }
+  }
+
+  def adapterOnClick[A](onclick: A ⇒ Any)(implicit cw: ContextWrapper) = {
+    Tweak[AbsListView](l ⇒ {
+      l.setOnItemClickListener(new OnItemClickListener {
+        override def onItemClick(adapterView: AdapterView[_], view: View, i: Int, l: Long): Unit = {
+          adapterView.getAdapter match {
+            case a: ListableListAdapter[A, _] ⇒ onclick(a.getItem(i))
+            case _ ⇒
+          }
+        }
+      })
+    })
+  }
+}

--- a/macroid-viewable/src/test/scala/macroid/viewable/ListableSpec.scala
+++ b/macroid-viewable/src/test/scala/macroid/viewable/ListableSpec.scala
@@ -1,0 +1,58 @@
+package macroid.viewable
+
+import android.os.Build.VERSION_CODES._
+import android.widget.{ ListView, TextView }
+import macroid.{ Ui, ActivityContext, ContextWrapper }
+import macroid.FullDsl._
+import org.robolectric.shadows.ShadowListView
+import org.robolectric.{ Shadows, Robolectric, RuntimeEnvironment }
+import org.robolectric.annotation.Config
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ FlatSpec, RobolectricSuite }
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/** Created by Alexey Afanasev on 25.02.16.
+  */
+@Config(sdk = Array(LOLLIPOP))
+class ListableSpec extends FlatSpec with ScalaFutures with RobolectricSuite with PageableList {
+  implicit val config = patienceConfig
+  implicit val ctx: ContextWrapper = ContextWrapper(RuntimeEnvironment.application)
+
+  case class User(name: String)
+  def usersStream(n: Int = 1): Stream[User] = Stream.cons(User(s"user$n"), usersStream(n + 1))
+  val users: Seq[User] = usersStream() take 50
+
+  val listable: Listable[User, TextView] = Listable[User] {
+    w[TextView]
+  } { view ⇒ data ⇒
+    view <~ text(data.name)
+  }
+
+  it should "work with adapters" in {
+    def ui = w[ListView] <~ listable.listAdapterTweak(users)
+    val eventualView: ListView = ui.run.futureValue
+
+    assert(eventualView.getAdapter.getCount === 50)
+    assert(eventualView.getAdapter.getItem(0).isInstanceOf[User])
+    assert(eventualView.getAdapter.getItem(0).asInstanceOf[User].name == "user1")
+  }
+
+  it should "work with pageable adapter" in {
+    def loadMore(position: Long)(implicit ec: ExecutionContext): Future[(Seq[User], Long)] = Future {
+      println(s"loadMore $position")
+      val p: Int = position.toInt
+      (users.slice(p, p + 20), users.length.toLong)
+    }
+
+    def ui: Ui[ListView] = w[ListView] <~ pagingAdapterTweak(loadMore, listable)
+    val eventualView: ListView = ui.run.futureValue
+    val shadowListView: ShadowListView = Shadows.shadowOf(eventualView)
+
+    assert(eventualView.getAdapter.getCount === 20)
+    shadowListView.getOnScrollListener.onScroll(eventualView, 10, 10, 20)
+
+  }
+
+}


### PR DESCRIPTION
The idea here is to introduce additional adapter tweak to simplify creating infinite ListView

```
case class User(name: String)
val listable: Listable[User, TextView] = ...
def loadMore(position: Long): Future[(Seq[User], Long)] = ...

def ui: Ui[ListView] = w[ListView] <~ pagingAdapterTweak(loadMore, listable)
```

Where `loadMore` returns data and total items count.
`pagingAdapterTweak` will setup `listAdapterTweak` and loads first page on its own.

I placed this tweak inside `viewable` since it depended on `listAdapterTweak` if there is a better place, will move.
